### PR TITLE
Lint and build in same stage so they run in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,17 @@ cache:
     - node_modules
 
 stages:
-  - lint
-  - build
+  - lint-and-build
   - name: deploy
     if: branch = master
 
 jobs:
   include:
-    - stage: lint
+    - stage: lint-and-build
       script:
         - npm install
         - npm run lint
-    - stage: build
+    - stage: lint-and-build
       script:
         - npm install
         - npm run dist


### PR DESCRIPTION
* Faster builds: 2 -> 1 min for branches, 3 -> 2 min for `master`
* If lint fails, we'll still get feedback on whether build passes/fails

# Before

![image](https://user-images.githubusercontent.com/1324225/93746218-6ea7a680-fbfd-11ea-8c74-3c46109ad8ba.png)

# After

![image](https://user-images.githubusercontent.com/1324225/93746163-59327c80-fbfd-11ea-8e5c-a690363cd394.png)
