### PR TITLE
updated the config.js to serve js file on react-foundation-docs/

### DIFF
--- a/webpack/config.js
+++ b/webpack/config.js
@@ -6,10 +6,10 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, '../dist'),
-    filename: '[name].[hash].js',
+    filename: 'react-foundation-docs/[name].[hash].js',
     publicPath: '/',
-    sourceMapFilename: '[name].[hash].js.map',
-    chunkFilename: '[id].chunk.js'
+    sourceMapFilename: 'react-foundation-docs/[name].[hash].js.map',
+    chunkFilename: 'react-foundation-docs/[id].chunk.js'
   },
   resolve: {
     extensions: ['.js']


### PR DESCRIPTION
Fixes # Fix routing / base of React app at GitHub Pages #29

Changes proposed in this pull request:

 * updated output object in the webpack/config.js file  to serve js files on the path react-foundation-docs/
   

