### PR TITLE
Open browser with 'npm run start'

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on: [push, pull_request]
 
 jobs:
-  lint:
+  pre-commit:
     runs-on: ubuntu-latest
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,5 +2,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
+      - id: check-json
       - id: check-merge-conflict
       - id: check-yaml

--- a/package.json
+++ b/package.json
@@ -4,21 +4,21 @@
   "description": "Documentation for React + Foundation",
   "main": "src/main.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --progress --colors --history-api-fallback --config webpack/development.js",
+    "start": "webpack-dev-server --inline --progress --colors --history-api-fallback --config webpack/development.js --open",
     "dist": "webpack -p --config webpack/production.js",
     "serve": "serve dist/",
     "lint": "eslint src"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nordsoftware/react-foundation-docs.git"
+    "url": "git+https://github.com/digiaonline/react-foundation-docs.git"
   },
   "author": "Christoffer Niska <christofferniska@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/nordsoftware/react-foundation-docs/issues"
+    "url": "https://github.com/digiaonline/react-foundation-docs/issues"
   },
-  "homepage": "https://github.com/nordsoftware/react-foundation-docs#readme",
+  "homepage": "https://github.com/digiaonline/react-foundation-docs#readme",
   "engines": {
     "node": "^10"
   },


### PR DESCRIPTION
Fixes https://github.com/digiaonline/react-foundation-docs/issues/26.

Changes proposed in this pull request:

 * Add `--open` switch so the browser is opened when `npm run start` is run
 * Also check JSON in pre-commit
 * Also update some redirected URLs
